### PR TITLE
Add Toast notifications to the Search/Map view

### DIFF
--- a/labs-ios-starter.xcodeproj/project.pbxproj
+++ b/labs-ios-starter.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		50FDDEA625BFC8AF007941CC /* FavoritesCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FDDEA525BFC8AF007941CC /* FavoritesCollectionViewController.swift */; };
 		50FDDEB025C09A96007941CC /* FavoriteCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FDDEAF25C09A96007941CC /* FavoriteCollectionViewCell.swift */; };
 		638CA13225C2674E00B996B9 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 638CA13125C2674E00B996B9 /* SearchViewController.swift */; };
+		63BF5D7E25D23F550096D5D4 /* ToastViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BF5D7D25D23F550096D5D4 /* ToastViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -59,6 +60,7 @@
 		50FDDEA525BFC8AF007941CC /* FavoritesCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesCollectionViewController.swift; sourceTree = "<group>"; };
 		50FDDEAF25C09A96007941CC /* FavoriteCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteCollectionViewCell.swift; sourceTree = "<group>"; };
 		638CA13125C2674E00B996B9 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		63BF5D7D25D23F550096D5D4 /* ToastViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -173,6 +175,7 @@
 			isa = PBXGroup;
 			children = (
 				638CA13125C2674E00B996B9 /* SearchViewController.swift */,
+				63BF5D7D25D23F550096D5D4 /* ToastViewController.swift */,
 			);
 			path = "Search & Map";
 			sourceTree = "<group>";
@@ -265,6 +268,7 @@
 				46BEB4E724C98D8900FE0CD1 /* Notifications.swift in Sources */,
 				46BEB4E124C9828800FE0CD1 /* Profile.swift in Sources */,
 				50FDDEA625BFC8AF007941CC /* FavoritesCollectionViewController.swift in Sources */,
+				63BF5D7E25D23F550096D5D4 /* ToastViewController.swift in Sources */,
 				46BEB4E924C98DAF00FE0CD1 /* ProfileListViewController.swift in Sources */,
 				463AD24524CF2CDB00447BB8 /* AddProfileViewController.swift in Sources */,
 				1753D83425BFE231004F9E73 /* MyProfileViewController.swift in Sources */,

--- a/labs-ios-starter/Info.plist
+++ b/labs-ios-starter/Info.plist
@@ -63,8 +63,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/labs-ios-starter/Login/Base.lproj/Main.storyboard
+++ b/labs-ios-starter/Login/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="4a7-cC-Xlp">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18121" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y9z-7g-ibd">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18091"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -318,13 +318,29 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="zSi-3b-abU">
-                                <rect key="frame" x="0.0" y="56" width="375" height="562"/>
+                                <rect key="frame" x="0.0" y="51" width="375" height="567"/>
                                 <connections>
                                     <outlet property="delegate" destination="9QV-Nz-J2q" id="SZl-qI-ekc"/>
                                 </connections>
                             </mapView>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Sgs-b1-7Ml" userLabel="Message">
+                                <rect key="frame" x="16" y="67" width="343" height="80"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="80" id="Zlb-UO-1wd"/>
+                                </constraints>
+                                <connections>
+                                    <segue destination="8Bk-bf-v3m" kind="embed" id="zIt-m5-t5o"/>
+                                </connections>
+                            </containerView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cs3-BG-RJg" userLabel="White Block">
+                                <rect key="frame" x="0.0" y="-100" width="375" height="100"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="100" id="9Ke-IX-ywt"/>
+                                </constraints>
+                            </view>
                             <searchBar contentMode="redraw" placeholder="Search a US city" showsCancelButton="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Pfm-H9-J0k">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="51"/>
                                 <textInputTraits key="textInputTraits"/>
                                 <scopeButtonTitles>
                                     <string>Title</string>
@@ -334,8 +350,8 @@
                                     <outlet property="delegate" destination="9QV-Nz-J2q" id="y36-NL-8xE"/>
                                 </connections>
                             </searchBar>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0bo-Vk-dPK">
-                                <rect key="frame" x="0.0" y="380" width="375" height="238"/>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0bo-Vk-dPK" userLabel="Detail">
+                                <rect key="frame" x="0.0" y="375" width="375" height="243"/>
                                 <connections>
                                     <segue destination="d9d-1f-IRx" kind="embed" id="f4m-uy-KBa"/>
                                 </connections>
@@ -344,11 +360,17 @@
                         <viewLayoutGuide key="safeArea" id="u2M-5P-ONF"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="u2M-5P-ONF" firstAttribute="trailing" secondItem="Sgs-b1-7Ml" secondAttribute="trailing" constant="16" id="4DM-yv-dCS"/>
+                            <constraint firstItem="Sgs-b1-7Ml" firstAttribute="leading" secondItem="u2M-5P-ONF" secondAttribute="leading" constant="16" id="4L1-Qv-CfV"/>
                             <constraint firstItem="zSi-3b-abU" firstAttribute="bottom" secondItem="u2M-5P-ONF" secondAttribute="bottom" id="FEK-m6-uPo"/>
                             <constraint firstItem="Pfm-H9-J0k" firstAttribute="leading" secondItem="u2M-5P-ONF" secondAttribute="leading" id="Lod-FI-F8R"/>
+                            <constraint firstItem="Cs3-BG-RJg" firstAttribute="trailing" secondItem="u2M-5P-ONF" secondAttribute="trailing" id="M5h-PC-Syd"/>
+                            <constraint firstItem="Cs3-BG-RJg" firstAttribute="top" secondItem="u2M-5P-ONF" secondAttribute="top" constant="-100" id="STn-E0-guF"/>
+                            <constraint firstItem="Cs3-BG-RJg" firstAttribute="leading" secondItem="u2M-5P-ONF" secondAttribute="leading" id="Sj9-qN-nU2"/>
                             <constraint firstItem="zSi-3b-abU" firstAttribute="trailing" secondItem="u2M-5P-ONF" secondAttribute="trailing" id="WR5-6Q-Rd6"/>
                             <constraint firstItem="zSi-3b-abU" firstAttribute="leading" secondItem="u2M-5P-ONF" secondAttribute="leading" id="ZlQ-we-iKc"/>
                             <constraint firstItem="0bo-Vk-dPK" firstAttribute="top" secondItem="Pfm-H9-J0k" secondAttribute="bottom" constant="324" id="cS3-nI-fqg"/>
+                            <constraint firstItem="Sgs-b1-7Ml" firstAttribute="top" secondItem="Pfm-H9-J0k" secondAttribute="bottom" constant="16" id="ehc-qV-uJR"/>
                             <constraint firstItem="0bo-Vk-dPK" firstAttribute="bottom" secondItem="u2M-5P-ONF" secondAttribute="bottom" id="gE6-uI-bAG"/>
                             <constraint firstItem="Pfm-H9-J0k" firstAttribute="top" secondItem="u2M-5P-ONF" secondAttribute="top" id="hdp-Xk-5Y2"/>
                             <constraint firstItem="0bo-Vk-dPK" firstAttribute="trailing" secondItem="u2M-5P-ONF" secondAttribute="trailing" id="jdy-Ud-ATZ"/>
@@ -397,7 +419,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="17" translatesAutoresizingMaskIntoConstraints="NO" id="C7b-Qv-MEf">
-                                <rect key="frame" x="20" y="69" width="335" height="136"/>
+                                <rect key="frame" x="20" y="65" width="335" height="136"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Name:" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UhE-9G-fp3">
                                         <rect key="frame" x="0.0" y="0.0" width="335" height="34"/>
@@ -417,7 +439,7 @@
                                 </subviews>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create Your Profile" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s8x-4x-PO2">
-                                <rect key="frame" x="20" y="20" width="335" height="41"/>
+                                <rect key="frame" x="20" y="20" width="335" height="37"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -439,7 +461,7 @@
                                 </items>
                             </toolbar>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="yu2-g9-PBg">
-                                <rect key="frame" x="169" y="285" width="37" height="37"/>
+                                <rect key="frame" x="169" y="281" width="37" height="37"/>
                             </activityIndicatorView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Qhm-Qa-x5Q"/>
@@ -474,16 +496,17 @@
             <objects>
                 <viewController id="d9d-1f-IRx" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="odw-dI-I4m">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="258"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="243"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="82f-hk-hEp">
-                                <rect key="frame" x="66" y="50" width="243" height="158"/>
+                                <rect key="frame" x="66" y="50" width="243" height="143"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="NSY-XW-XGE"/>
                         <color key="backgroundColor" systemColor="systemGreenColor"/>
                         <constraints>
                             <constraint firstItem="82f-hk-hEp" firstAttribute="leading" secondItem="odw-dI-I4m" secondAttribute="leadingMargin" constant="50" id="2tX-Gr-Ul2"/>
@@ -497,9 +520,90 @@
             </objects>
             <point key="canvasLocation" x="5542" y="-427"/>
         </scene>
+        <!--Toast View Controller-->
+        <scene sceneID="Obg-4Q-Lfw">
+            <objects>
+                <viewController id="8Bk-bf-v3m" customClass="ToastViewController" customModule="labs_ios_starter" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="1M9-cz-Lnm">
+                        <rect key="frame" x="0.0" y="0.0" width="343" height="80"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WhR-io-cVB">
+                                <rect key="frame" x="0.0" y="0.0" width="343" height="80"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3nX-bG-GEy">
+                                        <rect key="frame" x="0.0" y="0.0" width="263" height="80"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Data is only available for the United States." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dep-SA-RT2">
+                                                <rect key="frame" x="12" y="8" width="239" height="64"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="dep-SA-RT2" firstAttribute="leading" secondItem="3nX-bG-GEy" secondAttribute="leading" constant="12" id="Fmf-iS-yau"/>
+                                            <constraint firstAttribute="bottom" secondItem="dep-SA-RT2" secondAttribute="bottom" constant="8" id="Mdn-0W-DBL"/>
+                                            <constraint firstItem="dep-SA-RT2" firstAttribute="top" secondItem="3nX-bG-GEy" secondAttribute="top" constant="8" id="baT-YL-ByM"/>
+                                            <constraint firstAttribute="trailing" secondItem="dep-SA-RT2" secondAttribute="trailing" constant="12" id="gAc-Xl-u23"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9yD-RO-72k">
+                                        <rect key="frame" x="263" y="0.0" width="80" height="80"/>
+                                        <subviews>
+                                            <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="V7a-cB-h94" userLabel="Progress">
+                                                <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemBlueColor"/>
+                                            </view>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sRD-TG-VKV">
+                                                <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                                                <state key="normal" title="Close"/>
+                                                <connections>
+                                                    <action selector="closeButtonTapped:" destination="8Bk-bf-v3m" eventType="touchUpInside" id="u9a-bo-RhX"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemYellowColor"/>
+                                        <constraints>
+                                            <constraint firstItem="sRD-TG-VKV" firstAttribute="top" secondItem="9yD-RO-72k" secondAttribute="top" id="2g5-Z2-DDO"/>
+                                            <constraint firstAttribute="trailing" secondItem="V7a-cB-h94" secondAttribute="trailing" id="3TB-MX-epV"/>
+                                            <constraint firstItem="V7a-cB-h94" firstAttribute="top" secondItem="9yD-RO-72k" secondAttribute="top" id="5TE-2L-ON5"/>
+                                            <constraint firstAttribute="trailing" secondItem="sRD-TG-VKV" secondAttribute="trailing" id="7nU-7p-CoQ"/>
+                                            <constraint firstAttribute="bottom" secondItem="V7a-cB-h94" secondAttribute="bottom" id="J3C-Fy-FVR"/>
+                                            <constraint firstAttribute="bottom" secondItem="sRD-TG-VKV" secondAttribute="bottom" id="TO4-Lh-Mtu"/>
+                                            <constraint firstAttribute="bottom" secondItem="V7a-cB-h94" secondAttribute="bottom" id="Zhc-lP-w3J"/>
+                                            <constraint firstAttribute="width" secondItem="9yD-RO-72k" secondAttribute="height" multiplier="1:1" id="cwl-B8-rZH"/>
+                                            <constraint firstItem="sRD-TG-VKV" firstAttribute="leading" secondItem="9yD-RO-72k" secondAttribute="leading" id="kXI-Ju-zOp"/>
+                                            <constraint firstItem="V7a-cB-h94" firstAttribute="leading" secondItem="9yD-RO-72k" secondAttribute="leading" id="nZB-kN-hhc"/>
+                                            <constraint firstItem="V7a-cB-h94" firstAttribute="top" secondItem="9yD-RO-72k" secondAttribute="top" id="w13-nH-mU6"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="YTh-Hc-QGk"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="WhR-io-cVB" secondAttribute="bottom" id="2vv-Gi-532"/>
+                            <constraint firstItem="WhR-io-cVB" firstAttribute="leading" secondItem="1M9-cz-Lnm" secondAttribute="leading" id="7wY-36-AdH"/>
+                            <constraint firstItem="WhR-io-cVB" firstAttribute="top" secondItem="1M9-cz-Lnm" secondAttribute="top" id="Zay-8l-MiW"/>
+                            <constraint firstAttribute="trailing" secondItem="WhR-io-cVB" secondAttribute="trailing" id="ego-Lr-d4P"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="closeButtonArea" destination="9yD-RO-72k" id="xSN-v7-EyM"/>
+                        <outlet property="messageLabel" destination="dep-SA-RT2" id="95G-Sk-6sP"/>
+                        <outlet property="progressView" destination="V7a-cB-h94" id="HvQ-FT-Dpr"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Beg-T8-NJQ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5309.6000000000004" y="-736.73163418290858"/>
+        </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="OH0-zN-0GO"/>
+        <segue reference="f4m-uy-KBa"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="Male" width="200" height="248"/>
@@ -509,11 +613,17 @@
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemGray2Color">
             <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGreenColor">
             <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemYellowColor">
+            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/labs-ios-starter/Search & Map/ToastViewController.swift
+++ b/labs-ios-starter/Search & Map/ToastViewController.swift
@@ -1,0 +1,52 @@
+//
+//  ToastViewController.swift
+//  labs-ios-starter
+//
+//  Created by Chad Parker on 2/8/21.
+//  Copyright © 2021 Spencer Curtis. All rights reserved.
+//
+
+import UIKit
+
+class ToastViewController: UIViewController {
+
+    @IBOutlet weak var messageLabel: UILabel!
+    @IBOutlet weak var closeButtonArea: UIView!
+    @IBOutlet weak var progressView: UIView!
+    
+    let startPositionY: CGFloat = -100
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.alpha = 0
+    }
+    
+    func showMessage(_ message: String) {
+        messageLabel.text = message
+        
+        view.frame.origin.y = startPositionY
+        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut) {
+            self.view.frame.origin.y = 0
+            self.view.alpha = 1
+        }
+        
+        progressView.frame.size.width = 0
+        UIView.animate(withDuration: 5.0, delay: 0, options: .curveLinear) {
+            self.progressView.frame.size.width = self.closeButtonArea.frame.size.width
+        } completion: { finished in
+            self.hide()
+        }
+    }
+    
+    @IBAction func closeButtonTapped(_ sender: Any) {
+        self.hide()
+    }
+    
+    func hide() {
+        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut) {
+            self.view.frame.origin.y = self.startPositionY
+            self.view.alpha = 0
+        }
+    }
+}


### PR DESCRIPTION
# [Trello: Restrict map to US, includes a popup for exceptions](https://trello.com/c/A9LlmWcM)

## Files Modified:

- project.pbxproj
- Info.plist
- Main.storyboard
- SearchViewController.swift
- ToastViewController.swift

## Details:

1. [What is a “toast notification”?](https://ux.stackexchange.com/a/12000/119762)
2. The look of the notification needs to be improved for sure, but functionally there.
3. I turned off landscape orientations while I was here, since the app is only designed for portrait at the moment.

## Committed Features:

1. User now receives notifications if the searched location can't be found, or if the device is offline
2. The toast notification will be visible for 5 seconds, with a visible progress bar, or can be dismissed manually
