### PR TITLE
Fix xcode/swift bug when using `error` inside of guard statement

### DIFF
--- a/labs-ios-starter/Search & Map/SearchViewController.swift
+++ b/labs-ios-starter/Search & Map/SearchViewController.swift
@@ -41,13 +41,13 @@ class SearchViewController: UIViewController, UISearchBarDelegate, MKMapViewDele
         let geocoder = CLGeocoder()
         geocoder.geocodeAddressString(query) { placemarks, error in
             guard error == nil else {
-                guard let error = error as? CLError else {
+                guard let clError = error as? CLError else {
                     NSLog("Geocode error was not a CLError: \(error!)")
                     return
                 }
                 
                 let message: String
-                switch error.code {
+                switch clError.code {
                 case .network:
                     message = "Network error. Please connect device to internet."
                 case .geocodeFoundNoResult:
@@ -56,7 +56,7 @@ class SearchViewController: UIViewController, UISearchBarDelegate, MKMapViewDele
                     message = "Location unknown."
                 default:
                     message = "Error occured. Please try again."
-                    NSLog("Unknown error occured: \((error as NSError).localizedDescription)")
+                    NSLog("Unknown error occured: \((clError as NSError).localizedDescription)")
                 }
                 self.toastVC.showMessage(message)
                 return


### PR DESCRIPTION
Swift got confused by which `error` I was referring to. Xcode 12.5+ fixes that bug.

Trello: N/A

## Files Modified:

- SearchViewController.swift

## Details:

1. This fixes that error in Xcode that you guys were having in that guard statement.

## Committed Features:

1. N/A